### PR TITLE
feat: sensor data container switched to a dict instead of a queue.

### DIFF
--- a/ISS/algorithms/sensors/carla_sensor.pyx
+++ b/ISS/algorithms/sensors/carla_sensor.pyx
@@ -21,11 +21,14 @@ class CarlaSensor(CarlaActor):
         self.sensor_type = copy.deepcopy(self.get_type_id())
         self.save_dir = base_save_dir + '/{}'.format(name)
         # Fix queue capacity to 2000, acting as fake circular queue
-        self.queue = Queue(2000)
+        # self.queue = Queue(2000)
+        self.data_cache = {
+            "data": None
+        }
         weak_self = weakref.ref(self)
         self.carla_actor.listen(lambda sensor_data: CarlaSensor.data_callback(weak_self,
                                                                          sensor_data,
-                                                                         self.queue))
+                                                                         self.data_cache))
 
         self.csv_fieldnames = ['frame',
                                'timestamp',
@@ -33,9 +36,13 @@ class CarlaSensor(CarlaActor):
                                'roll', 'pitch', 'yaw']
         self._first_frame = True
 
+    # @staticmethod
+    # def data_callback(weak_self, sensor_data, data_queue: Queue):
+    #     data_queue.put(sensor_data)
+
     @staticmethod
-    def data_callback(weak_self, sensor_data, data_queue: Queue):
-        data_queue.put(sensor_data)
+    def data_callback(weak_self, sensor_data, data_cache:dict):
+        data_cache["data"] = sensor_data
 
     def save_to_disk(self, frame_id, timestamp, debug=False):
         sensor_frame_id = 0

--- a/ISS/algorithms/utils/dataexchange/detection_3d.pyx
+++ b/ISS/algorithms/utils/dataexchange/detection_3d.pyx
@@ -228,7 +228,7 @@ class Detection3DInput(object):
         self.points = points
 
     def from_carla_lidar(self, lidar:CarlaLiDAR):
-        sensor_data = lidar.queue.get(True, 1.0)
+        sensor_data = lidar.data_cache["data"]
         # print(sensor_data)
         if sensor_data is not None:
             lidar_output = lidar.realtime_data(sensor_data)


### PR DESCRIPTION
I have switched the data container of sensors from a queue to a dict. Now there should not be any lag between realtime gameplay and preview windows.

PS: Remenber to update and rebuild your codes if you're using sensor inputs.